### PR TITLE
Require stable version for commerce module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0+",
   "require": {
     "drupal/admin_toolbar": "^1.15.0",
-    "drupal/commerce": "2.x-dev",
+    "drupal/commerce": "^2.0",
     "drupal/config_inspector": "1.x-dev",
     "drupal/ctools": "^3.0.0-alpha26",
     "drupal/entity": "1.x",


### PR DESCRIPTION
Commerce has had stable versions for some time now. Requiring the development version creates conflicts in projects that want to use the latest stable version instead.